### PR TITLE
[fix] Modify gtest installation method

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,7 +38,14 @@ RUN git config --system init.defaultBranch main && \
 RUN python3 -m pip install --break-system-packages --no-cache-dir online-judge-verify-helper 
 
 # Install gtest for testing
-RUN su vscode -c "${VCPKG_ROOT}/vcpkg install gtest"
+RUN cd /tmp && \
+    git clone https://github.com/google/googletest.git -b v1.17.0 && \
+    cd googletest && \
+    cmake -S . -B build -D BUILD_GMOCK=OFF && \
+    cd build && \
+    make && \
+    sudo make install && \
+    rm -rf /tmp/googletest
 
 # Install nektos/act for testing GitHub Actions locally
 RUN curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -3,8 +3,7 @@
         {
             "name": "Linux",
             "includePath": [
-                "${workspaceFolder}/**",
-                "${VCPKG_ROOT}/installed/**/include/**"
+                "${workspaceFolder}/**"
             ],
             "defines": [
                 "DEBUG"


### PR DESCRIPTION
- Replaced package manager installation with manual cloning and building from source.
- Updated c_cpp_properties.json to remove unnecessary include path.